### PR TITLE
jQuery ajax fail() update

### DIFF
--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -180,7 +180,7 @@ var EWD;
             (function(type) {
 
               function success(data) {
-                console.log('Ajax response for type ' + type + ': ' + JSON.stringify(data));
+                if (EWD.log) console.log('Ajax response for type ' + type + ': ' + JSON.stringify(data));
                 if (data.ewd_response !== false) {
                   handleResponse({
                     type: type,
@@ -191,7 +191,7 @@ var EWD;
               }
 
               function fail(error) {
-                console.log('Error occurred: ' + error);
+                if (EWD.log) console.log('Error occurred: ' + error);
                 var messageObj = {
                   message: {error: error}
                 };
@@ -223,8 +223,9 @@ var EWD;
                 .done(function(data) {
                   success(data);
                 })
-                .error(function(err) {
-                  var error = err.responseJSON.error;
+                .fail(function(jqXHR, textStatus, errorThrown) {
+                  var error = jqXHR.responseJSON ? jqXHR.responseJSON.error : '';
+									if (!error) error = 'Ajax call failed: ' + textStatus;
                   fail(error);
                 });
               }

--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -200,7 +200,7 @@ var EWD;
 
               var params = {
                 //url: '/ajax',
-                url: (url ? url : '') + '/ajax'
+                url: (url ? url : '') + '/ajax',
                 type: 'post',
                 contentType: 'application/json',
                 data: messageObj,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ewd-client",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Browser (websocket & HTTP) Client for QEWD applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
removed error() in favour of fail() (works from jQuery 1.5, error
doesn't work anymore with jQuery 3.0